### PR TITLE
Fix dependency specification

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 	"directories": {
 		"lib": "./lib"
 	},
-	"dependencies": {
+	"devDependencies": {
 		"vows": ">= 0.5.13"
 	},
 	"engines": ["node >= 0.4"]


### PR DESCRIPTION
Dependencies that are only used for unit tests should be specified in `devDependencies` so they aren't installed for normal use.
